### PR TITLE
Fix stats modal by aligning API endpoint and auth handling

### DIFF
--- a/src/pages/VocabularyPage.tsx
+++ b/src/pages/VocabularyPage.tsx
@@ -408,14 +408,30 @@ const VocabularyPage: React.FC = () => {
   };
 
   const loadStats = async () => {
+    if (!user) {
+      message.warning('请先登录后再查看统计');
+      setLoginVisible(true);
+      return;
+    }
+
     try {
       const response = await vocabularyService.getStats();
       if (response.code === 0) {
         setStats(response.data);
         setStatsVisible(true);
+      } else {
+        message.error(response.msg || '获取统计信息失败');
       }
-    } catch (error) {
-      message.error('获取统计信息失败');
+    } catch (error: any) {
+      if (error?.response?.status === 401) {
+        message.warning('登录已过期，请重新登录');
+        localStorage.removeItem('authToken');
+        localStorage.removeItem('currentUser');
+        setUser(null);
+        setLoginVisible(true);
+      } else {
+        message.error('获取统计信息失败');
+      }
     }
   };
 

--- a/src/services/vocabularyService.ts
+++ b/src/services/vocabularyService.ts
@@ -48,7 +48,7 @@ export class VocabularyService {
 
   async getStats(): Promise<ApiResponse<Stats>> {
     try {
-      const response = await api.get('/api/stats');
+      const response = await api.get('/api/word-tags/stats');
       return response.data;
     } catch (error) {
       throw new Error('Failed to fetch stats');


### PR DESCRIPTION
## Summary
- update the stats service to call the backend's /api/word-tags/stats endpoint
- gate the stats modal behind authentication and handle expired sessions more gracefully

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6908375bdcb48326a61225cfda45784c